### PR TITLE
APPS-9437 - Adding Button action guideline

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1102,7 +1102,6 @@ sampleButton.addAction(UIAction(handler: { [weak self] _ in
 
 ```swift
 sampleButton.addTarget(self, action: #selector(yourButton), for: .touchUpInside)
-  """
 ```
 
 ## No Emoji

--- a/README.markdown
+++ b/README.markdown
@@ -1092,16 +1092,19 @@ When adding actions to buttons programatically, you're encouraged to move away f
 **Preferred**:
 
 ```swift
-sampleButton.addAction(UIAction(handler: { [weak self] _ in
-                guard let self = self else { return }
-                self.yourFunction
-            }), for: .touchUpInside)
+sampleButton.addAction(UIAction(
+                handler: { [weak self] _ in
+                    guard let self = self else { return }
+                    self.yourFunction 
+                 }), 
+                for: .touchUpInside)
 ```
 
 **Not Preferred**:
 
 ```swift
-sampleButton.addTarget(self, action: #selector(yourButton), for: .touchUpInside)
+sampleButton.addTarget(self, action: #selector(yourButton), 
+                             for: .touchUpInside)
 ```
 
 ## No Emoji

--- a/README.markdown
+++ b/README.markdown
@@ -1095,7 +1095,7 @@ When adding actions to buttons programatically, you're encouraged to move away f
 sampleButton.addAction(UIAction(
                 handler: { [weak self] _ in
                     guard let self = self else { return }
-                    self.yourFunction 
+                    self.yourFunction() 
                  }), 
                 for: .touchUpInside)
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -1105,17 +1105,6 @@ sampleButton.addTarget(self, action: #selector(yourButton), for: .touchUpInside)
   """
 ```
 
-**Not Preferred**:
-
-```swift
-let message = "You cannot charge the flux " +
-  "capacitor with a 9V battery.\n" +
-  "You must use a super-charger " +
-  "which costs 10 credits. You currently " +
-  "have \(credits) credits available."
-```
-
-
 ## No Emoji
 
 Do not use emoji in your projects. For those readers who actually type in their code, it's an unnecessary source of friction. While it may be cute, it doesn't add to the learning and it interrupts the coding flow for these readers.

--- a/README.markdown
+++ b/README.markdown
@@ -1085,6 +1085,37 @@ let message = "You cannot charge the flux " +
   "have \(credits) credits available."
 ```
 
+## Adding Actions to Buttons
+
+When adding actions to buttons programatically, you're encouraged to move away from having to use @objc tags when referencing functions by utilizing addAction instead of addTarget. 
+
+**Preferred**:
+
+```swift
+sampleButton.addAction(UIAction(handler: { [weak self] _ in
+                guard let self = self else { return }
+                self.yourFunction
+            }), for: .touchUpInside)
+```
+
+**Not Preferred**:
+
+```swift
+sampleButton.addTarget(self, action: #selector(yourButton), for: .touchUpInside)
+  """
+```
+
+**Not Preferred**:
+
+```swift
+let message = "You cannot charge the flux " +
+  "capacitor with a 9V battery.\n" +
+  "You must use a super-charger " +
+  "which costs 10 credits. You currently " +
+  "have \(credits) credits available."
+```
+
+
 ## No Emoji
 
 Do not use emoji in your projects. For those readers who actually type in their code, it's an unnecessary source of friction. While it may be cute, it doesn't add to the learning and it interrupts the coding flow for these readers.

--- a/README.markdown
+++ b/README.markdown
@@ -1103,7 +1103,7 @@ sampleButton.addAction(UIAction(
 **Not Preferred**:
 
 ```swift
-sampleButton.addTarget(self, action: #selector(yourButton), 
+sampleButton.addTarget(self, action: #selector(yourSelectorFunction), 
                              for: .touchUpInside)
 ```
 


### PR DESCRIPTION
As part of tech debt week, adding guideline to encourage new members of our team to use addAction instead of addTarget for buttons. 